### PR TITLE
Update to KDE 6.8 and Lazarus 3.6.

### DIFF
--- a/io.github.cudatext.CudaText-Qt.yml
+++ b/io.github.cudatext.CudaText-Qt.yml
@@ -1,6 +1,6 @@
 app-id: io.github.cudatext.CudaText-Qt
 runtime: org.kde.Platform
-runtime-version: '6.6'
+runtime-version: '6.8'
 sdk: org.kde.Sdk
 build-options:
   append-path: /app/lib/sdk/freepascal/bin
@@ -77,8 +77,8 @@ modules:
   - name: lazarus
     sources:
       - type: archive
-        url: https://gitlab.com/freepascal.org/lazarus/lazarus/-/archive/lazarus_3_0/lazarus-lazarus_3_0.tar.gz
-        sha256: b16f1f6339d43bef8a1ecedd854a2065e60136fdca75149c6321f5c5b54f49dd
+        url: https://gitlab.com/freepascal.org/lazarus/lazarus/-/archive/lazarus_3_6/lazarus-lazarus_3_6.tar.gz
+        sha256: 535c01c9f6dc00867753b2a4d4e08b12fc8939ed314b5179c8bcb19f7d836f35
     buildsystem: simple
     build-options:
       append-path: /app/lib/sdk/freepascal/bin


### PR DESCRIPTION
The KDE 6.6 runtime is end-of-life, and apparently Lazarus had 6 whole releases since the last time that dependency was updated. I'm currently running it on my own system, and it's working fine.